### PR TITLE
fix: correct PATH_TO_CMD constant

### DIFF
--- a/src/lib/CompileCommand.ts
+++ b/src/lib/CompileCommand.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import * as pathUtils from './PathUtils';
 import { outputChannel } from '../extension';
 
-const PATH_TO_CMD: string = '/Windows/System32/cmd.exe';
+const PATH_TO_CMD: string = 'C:\\Windows\\System32\\cmd.exe';
 
 /**
  * @brief Runs all support function to compile a quartus project and start a terminal with running compilation


### PR DESCRIPTION
Correct `PATH_TO_CMD` constant to avoid "Path to shell executable does not exist" error when starting compile.

<img width="501" height="157" alt="image" src="https://github.com/user-attachments/assets/7e3a2c63-ccda-4507-9aba-7f2890dc7c14" />
