### PR TITLE
fix: add fallback for `getProjectOutputDir`

### DIFF
--- a/src/lib/QuartusUtils.ts
+++ b/src/lib/QuartusUtils.ts
@@ -260,7 +260,7 @@ export function getProjectVerilogSourceFiles(context: vscode.ExtensionContext, c
  * @returns A path to the compile path
  */
 export function getProjectOutputDir(context: vscode.ExtensionContext, currentProjectPath: string, quartusBinPath: string): string {
-    return getProjectGlobal(context, currentProjectPath, quartusBinPath, 'PROJECT_OUTPUT_DIRECTORY')[0];
+    return getProjectGlobal(context, currentProjectPath, quartusBinPath, 'PROJECT_OUTPUT_DIRECTORY')[0] ?? "";
 }
 
 /**


### PR DESCRIPTION
Add fallback for `getProjectOutputDir` to avoid `The "path" argument must be of type string. Received undefined` error when opening programmer if the `PROJECT_OUTPUT_DIRECTORY` variable does not exist.

<img width="465" height="78" alt="image" src="https://github.com/user-attachments/assets/0434079a-4b01-4a0b-a76e-eb2280c47b8f" />
